### PR TITLE
Update Toastr.php

### DIFF
--- a/src/narutimateum/Toastr/Toastr.php
+++ b/src/narutimateum/Toastr/Toastr.php
@@ -47,7 +47,7 @@ class Toastr {
      */
     public function render() {
         $notifications = $this->session->get('toastr::notifications');
-        if(!$notifications) $notifications = [];
+        if(!$notifications) return;
 
         $output = '<script type="text/javascript">';
         $lastConfig = [];


### PR DESCRIPTION
When rendering a toastr without any notifications there is no need to return an empty script element, just return if there is no notifications.